### PR TITLE
Add tests to confirm the `heading` and `description` for the table can be seen

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ won't be generated.
   - [x] It can reset table filters
   - [x] It has table actions
   - [x] It has table bulk actions
+  - [x] It has the correct table heading
+  - [x] It has the correct table description
   - [ ] It can filter table records
   - [ ] It can remove table filters
 

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -115,6 +115,26 @@ class FilamentTestsCommand extends Command
         return $this->getResourceTable($resource)->isPaginated();
     }
 
+    protected function tableHasHeading(Resource $resource): bool
+    {
+        return $this->getResourceTable($resource)->getHeading() !== null;
+    }
+
+    protected function getTableHeading(Resource $resource): ?string
+    {
+        return $this->getResourceTable($resource)->getHeading();
+    }
+
+    protected function tableHasDescription(Resource $resource): bool
+    {
+        return $this->getResourceTable($resource)->getDescription() !== null;
+    }
+
+    protected function getTableDescription(Resource $resource): ?string
+    {
+        return $this->getResourceTable($resource)->getDescription();
+    }
+
     protected function getTableDefaultPaginationPageOption(Resource $resource): int|string|null
     {
         return $this->getResourceTable($resource)->getDefaultPaginationPageOption();
@@ -311,6 +331,14 @@ class FilamentTestsCommand extends Command
 
             if ($this->tableHasPagination($resource)) {
                 $stubs[] = $this->getStubPath('ListRecordsPaginated', 'Page/Index');
+            }
+
+            if ($this->tableHasHeading($resource)) {
+                $stubs[] = $this->getStubPath('Heading', 'Page/Index/Table');
+            }
+
+            if ($this->tableHasDescription($resource)) {
+                $stubs[] = $this->getStubPath('Description', 'Page/Index/Table');
             }
         }
 
@@ -591,6 +619,8 @@ class FilamentTestsCommand extends Command
             'RESOURCE_TABLE_TOGGLEABLE_COLUMNS' => $this->getToggleableColumns($resource)->keys(),
             'RESOURCE_TABLE_ACTIONS' => $this->getTableActionNames($resource)->keys(),
             'RESOURCE_TABLE_BULK_ACTIONS' => $this->getTableBulkActionNames($resource)->keys(),
+            'RESOURCE_TABLE_HEADING' => str($this->getTableHeading($resource))->wrap('\''),
+            'RESOURCE_TABLE_DESCRIPTION' => str($this->getTableDescription($resource))->wrap('\''),
             'DEFAULT_PER_PAGE_OPTION' => $this->getTableDefaultPaginationPageOption($resource),
             'DEFAULT_PAGINATED_RECORDS_FACTORY_COUNT' => $this->getTableDefaultPaginationPageOption($resource) * 2,
         ];

--- a/stubs/Page/Index/Table/Description.stub
+++ b/stubs/Page/Index/Table/Description.stub
@@ -1,0 +1,4 @@
+it('has the correct table description', function () {
+    livewire(List{{ MODEL_PLURAL_NAME }}::class)
+        ->assertSee({{ RESOURCE_TABLE_DESCRIPTION }}, escape: false);
+}){{ RESOLVED_GROUP_METHOD }};

--- a/stubs/Page/Index/Table/Heading.stub
+++ b/stubs/Page/Index/Table/Heading.stub
@@ -1,0 +1,4 @@
+it('has the correct table heading', function () {
+    livewire(List{{ MODEL_PLURAL_NAME }}::class)
+        ->assertSee({{ RESOURCE_TABLE_HEADING }}, escape: false);
+}){{ RESOLVED_GROUP_METHOD }};


### PR DESCRIPTION


Note: Its using `escape: false` because `heading` and `description` both support `Htmlable`