### PR TITLE
Add output similar to `artisan about`

### DIFF
--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -267,7 +267,7 @@ class FilamentTestsCommand extends Command
             'todos' => $resources['selected']->sum('todos'),
             'duration' => $resources['selected']->sum(function ($item) {
                 return (int) str_replace('ms', '', $item['duration']);
-            })
+            }),
         ];
 
         $resources->each(function ($items, $status) {

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -287,7 +287,7 @@ class FilamentTestsCommand extends Command
                     $this->components->twoColumnDetail('No. of Test(s)', $item['tests']);
 
                     if ($item['todos'] > 0) {
-                        $this->components->twoColumnDetail('No. of Todo(s)', '<fg=blue>'.$item['todos'].'</>');
+                        $this->components->twoColumnDetail('No. of Todo(s)', $item['todos']);
                     }
 
                     $this->components->twoColumnDetail('Duration', $item['duration']);

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -262,13 +262,13 @@ class FilamentTestsCommand extends Command
         // we need to unset otherwise a new section will be created for "todos"
         unset($resources['todos']);
 
-        $totals = $resources['selected']->reduce(function ($carry, $item) {
-            $carry['tests'] += $item['tests'];
-            $carry['todos'] += $item['todos'];
-            $carry['duration'] += $item['duration'];
-
-            return $carry;
-        }, ['tests' => 0, 'todos' => 0, 'duration' => 0]);
+        $totals = [
+            'tests' => $resources['selected']->sum('tests'),
+            'todos' => $resources['selected']->sum('todos'),
+            'duration' => $resources['selected']->sum(function ($item) {
+                return (int) str_replace('ms', '', $item['duration']);
+            })
+        ];
 
         $resources->each(function ($items, $status) {
 

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -280,11 +280,9 @@ class FilamentTestsCommand extends Command
             $items->each(function ($item) use ($status, $color, $statusHeading) {
                 $this->newLine();
 
-                // Display the resource name with its status color and heading
                 $this->components->twoColumnDetail('<fg='.$color.';options=bold>'.$item['name'].'</>', '<fg='.$color.';options=bold>'.$statusHeading.'</>');
 
                 if ($status === 'selected') {
-                    // For 'selected' status, always show test details
                     $this->components->twoColumnDetail('No. of Tests', $item['tests']);
                     $this->components->twoColumnDetail('Duration', $item['duration']);
 

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -284,10 +284,10 @@ class FilamentTestsCommand extends Command
                 $this->components->twoColumnDetail('<fg='.$color.';options=bold>'.$item['name'].'</>', '<fg='.$color.';options=bold>'.$statusHeading.'</>');
 
                 if ($status === 'selected') {
-                    $this->components->twoColumnDetail('No. of Tests', $item['tests']);
+                    $this->components->twoColumnDetail('No. of Test(s)', $item['tests']);
 
                     if ($item['todos'] > 0) {
-                        $this->components->twoColumnDetail('Todos', '<fg=blue>'.$item['todos'].'</>');
+                        $this->components->twoColumnDetail('No. of Todo(s)', '<fg=blue>'.$item['todos'].'</>');
                     }
 
                     $this->components->twoColumnDetail('Duration', $item['duration']);

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -285,11 +285,12 @@ class FilamentTestsCommand extends Command
 
                 if ($status === 'selected') {
                     $this->components->twoColumnDetail('No. of Tests', $item['tests']);
-                    $this->components->twoColumnDetail('Duration', $item['duration']);
 
                     if ($item['todos'] > 0) {
                         $this->components->twoColumnDetail('  <fg=blue>Todos</>', '<fg=blue>'.$item['todos'].'</>');
                     }
+
+                    $this->components->twoColumnDetail('Duration', $item['duration']);
                 }
             });
         });

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -259,6 +259,7 @@ class FilamentTestsCommand extends Command
             return $item;
         });
 
+        // we need to unset otherwise a new section will be created for "todos"
         unset($resources['todos']);
 
         $resources->each(function ($items, $status) {

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -287,7 +287,7 @@ class FilamentTestsCommand extends Command
                     $this->components->twoColumnDetail('No. of Tests', $item['tests']);
 
                     if ($item['todos'] > 0) {
-                        $this->components->twoColumnDetail('  <fg=blue>Todos</>', '<fg=blue>'.$item['todos'].'</>');
+                        $this->components->twoColumnDetail('Todos', '<fg=blue>'.$item['todos'].'</>');
                     }
 
                     $this->components->twoColumnDetail('Duration', $item['duration']);

--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -40,6 +40,7 @@ class FilamentTestsCommand extends Command
     {
         return new StubHandler($resource);
     }
+
     public function handle(): int
     {
         $this->numTests = 0;
@@ -91,6 +92,7 @@ class FilamentTestsCommand extends Command
             if ($this->files->exists($path) && ! $this->option('force')) {
                 if (! confirm("The test for {$selectedResource} already exists. Do you want to overwrite it?")) {
                     $this->skippedResources->push(['name' => $this->getNormalizedResourceName($selectedResource)]);
+
                     continue;
                 }
             }
@@ -181,7 +183,7 @@ class FilamentTestsCommand extends Command
         $this->selectedResources->push([
             'name' => $resourceName,
             'tests' => $numTests,
-            'duration' => round($end - $start, 3) * 1000 . 'ms',
+            'duration' => round($end - $start, 3) * 1000 .'ms',
         ]);
 
         return $contents;
@@ -243,7 +245,7 @@ class FilamentTestsCommand extends Command
                 default => 'UNKNOWN',
             };
 
-            $items->each(function ($item) use ($status, $color, $statusHeading){
+            $items->each(function ($item) use ($status, $color, $statusHeading) {
                 $this->newLine();
 
                 $this->components->twoColumnDetail('  <fg='.$color.';options=bold>'.$item['name'].'</>', '  <fg='.$color.';options=bold>'.$statusHeading.'</>');

--- a/src/Handlers/StubHandler.php
+++ b/src/Handlers/StubHandler.php
@@ -22,6 +22,7 @@ class StubHandler
     {
         $resource = $this->resource;
 
+
         $stubs = [
             \CodeWithDennis\FilamentTests\Stubs\SetupStub::make($resource)->get(),
 
@@ -68,8 +69,22 @@ class StubHandler
             \CodeWithDennis\FilamentTests\Stubs\Page\Edit\Render::make($resource)->get(),
 
             \CodeWithDennis\FilamentTests\Stubs\Page\View\Render::make($resource)->get(),
+
+            ...$this->getTodoStubs(),
         ];
 
+
         return collect($stubs);
+    }
+
+    protected function getTodoStubs()
+    {
+       return collect(scandir(__DIR__.'/../Stubs'))
+            ->filter(fn ($file) => str_ends_with($file, '.php'))
+            ->map(fn ($file) => str_replace('.php', '', $file))
+            ->map(fn ($file) => '\\CodeWithDennis\\FilamentTests\\Stubs\\'.$file)
+            ->map(fn ($file) => new $file($this->resource))
+            ->filter(fn ($file) => $file->isTodo())
+            ->map(fn ($file) => $file->get());
     }
 }

--- a/src/Handlers/StubHandler.php
+++ b/src/Handlers/StubHandler.php
@@ -22,7 +22,6 @@ class StubHandler
     {
         $resource = $this->resource;
 
-
         $stubs = [
             \CodeWithDennis\FilamentTests\Stubs\SetupStub::make($resource)->get(),
 
@@ -73,13 +72,12 @@ class StubHandler
             ...$this->getTodoStubs(),
         ];
 
-
         return collect($stubs);
     }
 
     protected function getTodoStubs()
     {
-       return collect(scandir(__DIR__.'/../Stubs'))
+        return collect(scandir(__DIR__.'/../Stubs'))
             ->filter(fn ($file) => str_ends_with($file, '.php'))
             ->map(fn ($file) => str_replace('.php', '', $file))
             ->map(fn ($file) => '\\CodeWithDennis\\FilamentTests\\Stubs\\'.$file)


### PR DESCRIPTION
This PR adds an output similar to `php artisan about` for each resource.

It holds additional details just as todos, duration and additionally the totals.


![Screenshot 2024-04-12 215351](https://github.com/CodeWithDennis/filament-tests/assets/11778632/7686bb59-d330-4b29-b951-104c2ae2f0fb)
