### PR TITLE
Add a new stub (class && .stub) with command

### DIFF
--- a/src/Commands/FilamentTestsCreateStubCommand.php
+++ b/src/Commands/FilamentTestsCreateStubCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace CodeWithDennis\FilamentTests\Commands;
+
+use CodeWithDennis\FilamentTests\Handlers\StubHandler;
+use Filament\Facades\Filament;
+use Filament\Resources\Resource;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multiselect;
+
+class FilamentTestsCreateStubCommand extends Command
+{
+    protected $signature = 'make:filament-test-stub
+                            {name : The name of the stub}
+                            {description : The description of the stub}
+                            {--t|todo : Generate as todo}
+                            {--f|force : Force overwrite the existing stub}';
+
+    protected $description = 'Create a new stub';
+
+    protected ?string $emoji = null;
+
+    public function __construct(protected Filesystem $files)
+    {
+        parent::__construct();
+        $this->selectRandomEmoji();
+    }
+
+    public function handle() : int
+    {
+        $this->generateStub();
+
+        return self::SUCCESS;
+    }
+
+    protected function generateStub(): array
+    {
+        $name = $this->argument('name');
+        $description = $this->argument('description');
+        $isTodoStub = $this->option('todo');
+
+        $normalizedPath = collect(explode('.', $name))
+            ->map(fn($part) => collect(explode('/', $part))
+                ->map(fn($subPart) => ucfirst($subPart))
+                ->implode(DIRECTORY_SEPARATOR)
+            );
+
+        $className = ucfirst($normalizedPath->pop());
+
+        $stubsBasePath = realpath(__DIR__ . '/../../stubs');
+        $stubsCurrentPath = $stubsBasePath;
+        $classesBasePath = realpath(__DIR__ . '/../Stubs');
+        $classesCurrentPath = $classesBasePath;
+
+        $normalizedPath->each(function ($part) use (&$stubsCurrentPath, &$classesCurrentPath) {
+            $stubsCurrentPath .= DIRECTORY_SEPARATOR . $part;
+            $classesCurrentPath .= DIRECTORY_SEPARATOR . $part;
+            $this->files->ensureDirectoryExists($stubsCurrentPath);
+            $this->files->ensureDirectoryExists($classesCurrentPath);
+        });
+
+        $stubTemplateFile = $stubsBasePath . DIRECTORY_SEPARATOR . ($isTodoStub ? '_todo.stub' : '_stub.stub');
+        $classTemplateFile = $stubsBasePath . DIRECTORY_SEPARATOR . ($isTodoStub ? '_todo.class' : '_stub.class');
+
+        $stubFile = $stubsCurrentPath . DIRECTORY_SEPARATOR . $className . '.stub';
+        $this->createFileFromTemplate($stubFile, $stubTemplateFile, $description, $className, false);
+
+        $classFile = $classesCurrentPath . DIRECTORY_SEPARATOR . $className . '.php';
+        $this->createFileFromTemplate($classFile, $classTemplateFile, $description, $className, true);
+
+        return collect([$name, $description])->all();
+    }
+
+    protected function selectRandomEmoji(): void
+    {
+        $randomEmoji = collect(['🚀', '🔥', '🌟', '🎉', '👍', '👏', '🙌', '💪', '🤝', '👀', '🔖']);
+        $this->emoji = $randomEmoji->random();
+    }
+
+    protected function createFileFromTemplate($filePath, $templatePath, $description, $className, $isClassFile): void
+    {
+        $content = $this->files->get($templatePath);
+        $content = str_replace('{{ DESCRIPTION }}', $description, $content);
+
+        if ($isClassFile) {
+            $content = str_replace('{{ NAME }}', $className, $content);
+
+            $namespacePath = str_replace([realpath(__DIR__ . '/../Stubs'), DIRECTORY_SEPARATOR], ['', '\\'], dirname($filePath));
+            $namespace = trim('CodeWithDennis\FilamentTests\Stubs' . $namespacePath, '\\');
+            $content = str_replace('{{ NAMESPACE }}', 'namespace ' . $namespace . ';', $content);
+
+            if (str_contains($content, '{{ IMPORT_CLOSURE }}')) {
+                $content = str_replace('{{ IMPORT_CLOSURE }}', 'use Closure;', $content);
+            }
+        }
+
+        if ($this->files->exists($filePath) && !$this->option('force')) {
+            if (!$this->confirm("The {$filePath} file already exists. Do you want to overwrite it?")) {
+                return;
+            }
+        }
+
+        $this->files->put($filePath, $content);
+        $this->info("File created: {$filePath} {$this->emoji}");
+    }
+}

--- a/src/Commands/FilamentTestsCreateStubCommand.php
+++ b/src/Commands/FilamentTestsCreateStubCommand.php
@@ -2,15 +2,8 @@
 
 namespace CodeWithDennis\FilamentTests\Commands;
 
-use CodeWithDennis\FilamentTests\Handlers\StubHandler;
-use Filament\Facades\Filament;
-use Filament\Resources\Resource;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Collection;
-
-use function Laravel\Prompts\confirm;
-use function Laravel\Prompts\multiselect;
 
 class FilamentTestsCreateStubCommand extends Command
 {
@@ -30,7 +23,7 @@ class FilamentTestsCreateStubCommand extends Command
         $this->selectRandomEmoji();
     }
 
-    public function handle() : int
+    public function handle(): int
     {
         $this->generateStub();
 
@@ -44,32 +37,32 @@ class FilamentTestsCreateStubCommand extends Command
         $isTodoStub = $this->option('todo');
 
         $normalizedPath = collect(explode('.', $name))
-            ->map(fn($part) => collect(explode('/', $part))
-                ->map(fn($subPart) => ucfirst($subPart))
+            ->map(fn ($part) => collect(explode('/', $part))
+                ->map(fn ($subPart) => ucfirst($subPart))
                 ->implode(DIRECTORY_SEPARATOR)
             );
 
         $className = ucfirst($normalizedPath->pop());
 
-        $stubsBasePath = realpath(__DIR__ . '/../../stubs');
+        $stubsBasePath = realpath(__DIR__.'/../../stubs');
         $stubsCurrentPath = $stubsBasePath;
-        $classesBasePath = realpath(__DIR__ . '/../Stubs');
+        $classesBasePath = realpath(__DIR__.'/../Stubs');
         $classesCurrentPath = $classesBasePath;
 
         $normalizedPath->each(function ($part) use (&$stubsCurrentPath, &$classesCurrentPath) {
-            $stubsCurrentPath .= DIRECTORY_SEPARATOR . $part;
-            $classesCurrentPath .= DIRECTORY_SEPARATOR . $part;
+            $stubsCurrentPath .= DIRECTORY_SEPARATOR.$part;
+            $classesCurrentPath .= DIRECTORY_SEPARATOR.$part;
             $this->files->ensureDirectoryExists($stubsCurrentPath);
             $this->files->ensureDirectoryExists($classesCurrentPath);
         });
 
-        $stubTemplateFile = $stubsBasePath . DIRECTORY_SEPARATOR . ($isTodoStub ? '_todo.stub' : '_stub.stub');
-        $classTemplateFile = $stubsBasePath . DIRECTORY_SEPARATOR . ($isTodoStub ? '_todo.class' : '_stub.class');
+        $stubTemplateFile = $stubsBasePath.DIRECTORY_SEPARATOR.($isTodoStub ? '_todo.stub' : '_stub.stub');
+        $classTemplateFile = $stubsBasePath.DIRECTORY_SEPARATOR.($isTodoStub ? '_todo.class' : '_stub.class');
 
-        $stubFile = $stubsCurrentPath . DIRECTORY_SEPARATOR . $className . '.stub';
+        $stubFile = $stubsCurrentPath.DIRECTORY_SEPARATOR.$className.'.stub';
         $this->createFileFromTemplate($stubFile, $stubTemplateFile, $description, $className, false);
 
-        $classFile = $classesCurrentPath . DIRECTORY_SEPARATOR . $className . '.php';
+        $classFile = $classesCurrentPath.DIRECTORY_SEPARATOR.$className.'.php';
         $this->createFileFromTemplate($classFile, $classTemplateFile, $description, $className, true);
 
         return collect([$name, $description])->all();
@@ -89,17 +82,17 @@ class FilamentTestsCreateStubCommand extends Command
         if ($isClassFile) {
             $content = str_replace('{{ NAME }}', $className, $content);
 
-            $namespacePath = str_replace([realpath(__DIR__ . '/../Stubs'), DIRECTORY_SEPARATOR], ['', '\\'], dirname($filePath));
-            $namespace = trim('CodeWithDennis\FilamentTests\Stubs' . $namespacePath, '\\');
-            $content = str_replace('{{ NAMESPACE }}', 'namespace ' . $namespace . ';', $content);
+            $namespacePath = str_replace([realpath(__DIR__.'/../Stubs'), DIRECTORY_SEPARATOR], ['', '\\'], dirname($filePath));
+            $namespace = trim('CodeWithDennis\FilamentTests\Stubs'.$namespacePath, '\\');
+            $content = str_replace('{{ NAMESPACE }}', 'namespace '.$namespace.';', $content);
 
             if (str_contains($content, '{{ IMPORT_CLOSURE }}')) {
                 $content = str_replace('{{ IMPORT_CLOSURE }}', 'use Closure;', $content);
             }
         }
 
-        if ($this->files->exists($filePath) && !$this->option('force')) {
-            if (!$this->confirm("The {$filePath} file already exists. Do you want to overwrite it?")) {
+        if ($this->files->exists($filePath) && ! $this->option('force')) {
+            if (! $this->confirm("The {$filePath} file already exists. Do you want to overwrite it?")) {
                 return;
             }
         }

--- a/src/FilamentTestsServiceProvider.php
+++ b/src/FilamentTestsServiceProvider.php
@@ -3,6 +3,7 @@
 namespace CodeWithDennis\FilamentTests;
 
 use CodeWithDennis\FilamentTests\Commands\FilamentTestsCommand;
+use CodeWithDennis\FilamentTests\Commands\FilamentTestsCreateStubCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -13,6 +14,9 @@ class FilamentTestsServiceProvider extends PackageServiceProvider
         $package
             ->name('filament-tests')
             ->hasConfigFile()
-            ->hasCommand(FilamentTestsCommand::class);
+            ->hasCommands([
+                FilamentTestsCommand::class,
+                FilamentTestsCreateStubCommand::class,
+            ]);
     }
 }

--- a/src/Stubs/X/Y/Z.php
+++ b/src/Stubs/X/Y/Z.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace CodeWithDennis\FilamentTests\Stubs\X\Y;
+
+use Closure;
+use CodeWithDennis\FilamentTests\Stubs\Base;
+
+class Z extends Base
+{
+    public Closure|bool $isTodo = true;
+}

--- a/stubs/Page/Create/Actions/Test.stub
+++ b/stubs/Page/Create/Actions/Test.stub
@@ -1,0 +1,3 @@
+it('has the correct table description', function () {
+   //
+});

--- a/stubs/X/Y/Z.stub
+++ b/stubs/X/Y/Z.stub
@@ -1,0 +1,1 @@
+it('it does stuff')->todo();

--- a/stubs/X/Y/Z.stub
+++ b/stubs/X/Y/Z.stub
@@ -1,1 +1,1 @@
-it('it does stuff')->todo();
+it('does stuff')->todo();

--- a/stubs/_stub.class
+++ b/stubs/_stub.class
@@ -1,0 +1,10 @@
+<?php
+
+{{ NAMESPACE }}
+
+use CodeWithDennis\FilamentTests\Stubs\Base;
+
+class {{ NAME }} extends Base
+{
+    //
+}

--- a/stubs/_stub.stub
+++ b/stubs/_stub.stub
@@ -1,0 +1,3 @@
+it('{{ DESCRIPTION }}', function() {
+    //
+});

--- a/stubs/_todo.class
+++ b/stubs/_todo.class
@@ -1,0 +1,11 @@
+<?php
+
+{{ NAMESPACE }}
+
+{{ IMPORT_CLOSURE }}
+use CodeWithDennis\FilamentTests\Stubs\Base;
+
+class {{ NAME }} extends Base
+{
+    public Closure|bool $isTodo = true;
+}

--- a/stubs/_todo.stub
+++ b/stubs/_todo.stub
@@ -1,0 +1,1 @@
+it('{{ DESCRIPTION }}')->todo();


### PR DESCRIPTION
### THIS DEPENDS ON https://github.com/CodeWithDennis/filament-tests/pull/147

This PR adds an internal command to add new stubs. The following formats are supported.

> php artisan make:filament-test-stub {name:path} {description} -{options}

`php artisan make:filament-test-stub a.b.c.d "does stuff"`
`php artisan make:filament-test-stub A.B.C.D "does stuff"`
`php artisan make:filament-test-stub a/b/c/d "does stuff"`
`php artisan make:filament-test-stub A/B/C/D "does stuff"`

Would generate: 

A new file in: `../Stubs/A/B/C/D.php` as well as `../../stubs/A/B/C/D.stub`

You can pass `-t`or `--todo` to generate a todo instead.
It supports force overwrite with `-f` or `--force`

![Screenshot 2024-04-13 004732](https://github.com/CodeWithDennis/filament-tests/assets/11778632/b775453a-11a2-4902-99c1-dab96d072f08)

![Screenshot 2024-04-13 004758](https://github.com/CodeWithDennis/filament-tests/assets/11778632/bbe10895-a8e3-4dce-9709-54ed3a10250b)

![Screenshot 2024-04-13 004840](https://github.com/CodeWithDennis/filament-tests/assets/11778632/b8e0223b-0866-4bac-96f7-bdfcf9185e24)

Closes #148 