### PR TITLE
Use `class_basename()` to get the name of the resource to test

### DIFF
--- a/src/Commands/FilamentTestsCommand.php
+++ b/src/Commands/FilamentTestsCommand.php
@@ -144,7 +144,7 @@ class FilamentTestsCommand extends Command
 
     protected function getAvailableResources(): Collection
     {
-        return $this->getResources()->map(fn ($resource): string => str($resource)->afterLast('Resources\\'));
+        return $this->getResources()->map(fn ($resource): string => class_basename($resource));
     }
 
     protected function getSourceFilePath(string $name): string


### PR DESCRIPTION
When generating tests for a resource not in a `Resources` directory, the test file is given the name of the full FQDN of the resource under test, for example, the filename (not path) of a test for `SettingsResource` in the `Manage` cluster would be:

`App\Filament\Clusters\Manage\SettingsResource\SettingsResourceTest.php`

Similarly, when using the `directory_name` option, the name of the directory is also `App\Filament\Clusters\Manage\SettingsResource`.

![image](https://github.com/CodeWithDennis/filament-tests/assets/212036/2863a88f-5a49-4735-b250-586580534216)

The Filament docs [recommend ](https://filamentphp.com/docs/3.x/panels/clusters#code-structure-recommendations-for-panels-using-clusters) putting the resources in a `Resources` directory, but it's not a requirement.

Using Laravel's `class_basename()` helper will get the correct class name for the resource.
