### PR TITLE
Add dependencies && Add note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ php artisan vendor:publish --tag="filament-tests-stubs"
 ```
 
 ## Running the package tests
+> 💡 Please make sure that you have uncommented `Illuminate\Foundation\Testing\RefreshDatabase::class` in `tests/Pest.php` before running the tests.
 
 You can run your tests normally by running the following command:
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ php artisan vendor:publish --tag="filament-tests-stubs"
 
 ## Running the package tests
 > 💡 Please make sure to uncomment `Illuminate\Foundation\Testing\RefreshDatabase::class` in `tests/Pest.php` before running the tests.
+> 
+> Additionally, make sure to have a `.env.testing` file with a valid database connection or uncomment the `DB_CONNECTION` and `DB_DATABASE` values in the `phpunit.xml` file.
 
 You can run your tests normally by running the following command:
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ php artisan vendor:publish --tag="filament-tests-stubs"
 ```
 
 ## Running the package tests
-> 💡 Please make sure that you have uncommented `Illuminate\Foundation\Testing\RefreshDatabase::class` in `tests/Pest.php` before running the tests.
+> 💡 Please make sure to uncomment `Illuminate\Foundation\Testing\RefreshDatabase::class` in `tests/Pest.php` before running the tests.
 
 You can run your tests normally by running the following command:
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.14.0",
-        "illuminate/contracts": "^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0",
+        "pestphp/pest-plugin-livewire": "^2.1"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
This ensures tests can be run without any further interaction.

Though `pest-plugin-laravel` cannot be added as required since it needs `laravel/framework`